### PR TITLE
Fix typo when saving fresnel data in fit_alpha_theta.py

### DIFF
--- a/fitting/fit_alpha_theta.py
+++ b/fitting/fit_alpha_theta.py
@@ -261,7 +261,7 @@ def optimize_loop(args, lut_size, model, target):
     fresnel = fresnel.reshape(lut_size).cpu().numpy()
 
     np.save('%s/alpha_theta_amplitudes.npy' % (args.savedir), amplitudes)
-    np.save('%s/alpha_theta_fresnel.npy' % (args.savedir), amplitudes)
+    np.save('%s/alpha_theta_fresnel.npy' % (args.savedir), fresnel)
 
 
 


### PR DESCRIPTION
This PR fixes a typo in `fit_alpha_theta.py` when saving fresnel data to disk: the amplitudes got saved twice incorrectly.